### PR TITLE
Fix insertion index for root nodes in animated list

### DIFF
--- a/lib/tree_view/tree_view_state_helper.dart
+++ b/lib/tree_view/tree_view_state_helper.dart
@@ -127,7 +127,10 @@ class TreeViewStateHelper<Data> {
         animatedListStateController.insertAll(
           // This is crude fix to ensure we can insert at index 0 for root.
           // Best if upstream do fix the computeActualIndex func
-          parentNode.isRoot && actualIndex == 0 ? actualIndex : actualIndex + 1,
+          // Seems this one still breaks when we do insertBefore, the inserted node is off by 1
+          // parentNode.isRoot && actualIndex == 0 ? actualIndex : actualIndex + 1,
+          // Experimenting with pure actualIndex
+          actualIndex,
           List.from(event.items),
         );
       } else {

--- a/lib/tree_view/tree_view_state_helper.dart
+++ b/lib/tree_view/tree_view_state_helper.dart
@@ -127,10 +127,16 @@ class TreeViewStateHelper<Data> {
         animatedListStateController.insertAll(
           // This is crude fix to ensure we can insert at index 0 for root.
           // Best if upstream do fix the computeActualIndex func
+
           // Seems this one still breaks when we do insertBefore, the inserted node is off by 1
           // parentNode.isRoot && actualIndex == 0 ? actualIndex : actualIndex + 1,
-          // Experimenting with pure actualIndex
-          actualIndex,
+
+          // Experimenting with pure actualIndex -> pure index will work at root but screws up when moving up leaves,
+          // index become -1 instead of 0
+          // actualIndex,
+
+          // Trying natural for root only
+          parentNode.isRoot ? actualIndex : actualIndex + 1,
           List.from(event.items),
         );
       } else {

--- a/lib/tree_view/tree_view_state_helper.dart
+++ b/lib/tree_view/tree_view_state_helper.dart
@@ -135,8 +135,11 @@ class TreeViewStateHelper<Data> {
           // index become -1 instead of 0
           // actualIndex,
 
-          // Trying natural for root only
-          parentNode.isRoot ? actualIndex : actualIndex + 1,
+          // Trying natural for root only, This doesnt work with inserting new node to root:0!
+          // parentNode.isRoot ? actualIndex : actualIndex + 1,
+
+          // Try to force to use 0 when inserting to root:0 and fallback to actualindex + 1 for everything else
+          parentNode.isRoot && event.index == 0 ? 0 : actualIndex + 1,
           List.from(event.items),
         );
       } else {

--- a/lib/tree_view/tree_view_state_helper.dart
+++ b/lib/tree_view/tree_view_state_helper.dart
@@ -125,7 +125,9 @@ class TreeViewStateHelper<Data> {
             computeActualIndex(parentIndex + event.index, parentNode.level);
 
         animatedListStateController.insertAll(
-          actualIndex + 1,
+          // This is crude fix to ensure we can insert at index 0 for root.
+          // Best if upstream do fix the computeActualIndex func
+          parentNode.isRoot && actualIndex == 0 ? actualIndex : actualIndex + 1,
           List.from(event.items),
         );
       } else {


### PR DESCRIPTION
This is a monkey patch to fix:
- Impossible to insert into Root with index 0

Not thoroughly tested.

example:

 parent.insert(0, node); -> this will insert the node into 2nd [index:1] instead of 1st [index:0]
 
```
          TreeView.indexed(
            key: ValueKey(_sortMode),
            tree: _root,
            padding: const EdgeInsets.only(left: 16),
            showRootNode: false, // maybe this is the trigger for that error??
            indentation: const Indentation(style: IndentStyle.roundJoint),
            expansionBehavior: ExpansionBehavior.scrollToLastChild,
            animation: kAlwaysCompleteAnimation,

            expansionIndicatorBuilder: (context, node) => ChevronIndicator.rightDown(
              tree: node,
              color: AppTheme.text,
              padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 24),
              alignment: Alignment.topRight,
            ),
            onTreeReady: (controller) {
               ... action code
            },
            builder: (context, node) {
                .... builder code
            },
          ),
```